### PR TITLE
Add MMS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
-# Incoming SMS to URL forwarder
-This application provides a simple interface to send HTTP requests with information from incoming SMS messages and calls.
+# Incoming SMS/MMS to URL forwarder
+This application provides a simple interface to send HTTP requests with information from incoming SMS/MMS messages and calls.
 
 ## Available Placeholders
-* %from%
-* %fromName%
-* %text%
-* %messageType%
-* %sentStamp%
-* %receivedStamp%
-* %sim%
+* %from% - sender phone number
+* %fromName% - sender contact name (or phone number if not in contacts)
+* %text% - message body (SMS or MMS text content)
+* %messageType% - message type ("Incoming SMS", "Incoming MMS", "Incoming Call")
+* %sentStamp% - sent timestamp
+* %receivedStamp% - received timestamp
+* %sim% - SIM slot name
+* %mmsSubject% - MMS subject line (if present)
+* %mmsAttachmentB64% - MMS attachment as base64-encoded string
+* %mmsAttachmentType% - MMS attachment MIME type (eg. "image/jpeg")
+* %mmsFilename% - derived filename from MIME type (eg. "attachment.jpg")
 
+Placeholders may be used in the request's JSON body or headers.
+
+### MMS Attachment Upload
+For MMS messages with binary attachments (images, videos, contact cards, etc.), the app can optionally send a second HTTP request with the raw attachment data as the request body.
+
+The attachment upload has its own configuration:
+* URL - defaults to the webhook URL if not set
+* Method - PUT or POST
+* Headers
+
+### Group MMS
+For group MMS messages, `%fromName%` is formatted as:
+```
+Sender - Sender, Recipient1, Recipient2, ...
+```
+Your own number is excluded from the recipient list.
 
 ## Request Info
 HTTP method: POST  

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.RECEIVE_MMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/BinaryRequest.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/BinaryRequest.java
@@ -1,0 +1,164 @@
+package org.scottmconway.incomingsmsgateway;
+
+import android.annotation.SuppressLint;
+import android.util.Base64;
+import android.util.Log;
+
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Iterator;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import org.scottmconway.incomingsmsgateway.SSLSocketFactory.TLSSocketFactory;
+
+/**
+ * Sends raw binary data as the HTTP request body.
+ * Used for MMS attachment uploads (e.g. to ntfy).
+ */
+public class BinaryRequest {
+
+    private final byte[] data;
+    private final String contentType;
+    private boolean ignoreSsl = false;
+    private String error = null;
+    private HttpURLConnection connection;
+
+    public static final String RESULT_SUCCESS = "success";
+    public static final String RESULT_ERROR = "error";
+    public static final String RESULT_RETRY = "error_retry";
+
+    public BinaryRequest(String urlString, String method, byte[] data, String contentType) {
+        this.data = data;
+        this.contentType = contentType;
+
+        URL url;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            Log.e("SmsGateway", "malformed url error: " + urlString);
+            this.error = RESULT_ERROR;
+            return;
+        }
+
+        try {
+            this.connection = (HttpURLConnection) url.openConnection();
+            this.connection.setRequestMethod(method);
+        } catch (IOException e) {
+            Log.e("SmsGateway", "open connection error: " + e);
+            this.error = RESULT_ERROR;
+            return;
+        }
+
+        // Don't set Content-Type — let the user's configured headers control it.
+        // ntfy and similar services expect application/octet-stream (the default)
+        // rather than the attachment's MIME type.
+
+        if (url.getUserInfo() != null) {
+            String basicAuth = "Basic " + Base64.encodeToString(url.getUserInfo().getBytes(), 0);
+            this.connection.setRequestProperty("Authorization", basicAuth);
+        }
+    }
+
+    public void setJsonHeaders(String headers) {
+        JSONObject headersObj;
+        try {
+            headersObj = new JSONObject(headers);
+            Iterator<String> keys = headersObj.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                if (headersObj.get(key) instanceof JSONObject) {
+                    Log.e("SmsGateway", "only string supported in json");
+                    continue;
+                }
+                this.connection.setRequestProperty(key, (String) headersObj.get(key));
+            }
+        } catch (JSONException e) {
+            Log.e("SmsGateway", "headers error: " + e);
+            this.error = RESULT_ERROR;
+        }
+    }
+
+    public void setIgnoreSsl(boolean ignoreSsl) {
+        this.ignoreSsl = ignoreSsl;
+    }
+
+    @SuppressLint({"AllowAllHostnameVerifier"})
+    public String execute() {
+        if (this.error != null) {
+            return this.error;
+        }
+
+        String result = RESULT_SUCCESS;
+
+        try {
+            if (this.connection instanceof HttpsURLConnection) {
+                ((HttpsURLConnection) this.connection).setSSLSocketFactory(
+                        new TLSSocketFactory(this.ignoreSsl)
+                );
+                if (this.ignoreSsl) {
+                    ((HttpsURLConnection) this.connection).setHostnameVerifier(new AllowAllHostnameVerifier());
+                }
+            }
+
+            this.connection.setDoOutput(true);
+            this.connection.setFixedLengthStreamingMode(this.data.length);
+
+            OutputStream out = new BufferedOutputStream(this.connection.getOutputStream());
+            out.write(this.data);
+            out.flush();
+            out.close();
+
+            int responseCode = this.connection.getResponseCode();
+            if (responseCode / 100 != 2) {
+                String responseBody = "";
+                try {
+                    java.io.InputStream errStream = this.connection.getErrorStream();
+                    if (errStream != null) {
+                        java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.InputStreamReader(errStream));
+                        StringBuilder sb = new StringBuilder();
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            sb.append(line).append("\n");
+                        }
+                        reader.close();
+                        responseBody = sb.toString();
+                    }
+                } catch (IOException ignored) {}
+                Log.e("SmsGateway", "binary upload failed: HTTP " + responseCode
+                        + " url=" + this.connection.getURL()
+                        + " method=" + this.connection.getRequestMethod()
+                        + " contentType=" + this.contentType
+                        + " dataLen=" + this.data.length
+                        + " response: " + responseBody);
+                result = RESULT_RETRY;
+            }
+        } catch (NoSuchAlgorithmException e) {
+            Log.e("SmsGateway", "ssl algorithm error: " + e);
+            result = RESULT_ERROR;
+        } catch (KeyManagementException e) {
+            Log.e("SmsGateway", "ssl factory error: " + e);
+            result = RESULT_ERROR;
+        } catch (IOException e) {
+            Log.e("SmsGateway", "io error " + e);
+            result = RESULT_RETRY;
+        } finally {
+            if (this.connection != null) {
+                this.connection.disconnect();
+            }
+        }
+
+        return result;
+    }
+}

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/BinaryRequest.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/BinaryRequest.java
@@ -8,7 +8,6 @@ import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,7 +24,7 @@ import org.scottmconway.incomingsmsgateway.SSLSocketFactory.TLSSocketFactory;
 
 /**
  * Sends raw binary data as the HTTP request body.
- * Used for MMS attachment uploads (e.g. to ntfy).
+ * Used for MMS attachment uploads
  */
 public class BinaryRequest {
 
@@ -61,8 +60,8 @@ public class BinaryRequest {
             return;
         }
 
-        // Don't set Content-Type — let the user's configured headers control it.
-        // ntfy and similar services expect application/octet-stream (the default)
+        // Don't set Content-Type - let the user's configured headers control it.
+        // ntfy and similar services expect application/octet-stream
         // rather than the attachment's MIME type.
 
         if (url.getUserInfo() != null) {
@@ -121,7 +120,7 @@ public class BinaryRequest {
             out.close();
 
             int responseCode = this.connection.getResponseCode();
-            if (responseCode / 100 != 2) {
+            if (responseCode >= 400) {
                 String responseBody = "";
                 try {
                     java.io.InputStream errStream = this.connection.getErrorStream();

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
@@ -299,8 +299,8 @@ public class ForwardingConfig {
         editor.commit();
     }
 
-    public String prepareMessage(WebhookMessage message) {
-        return this.getTemplate()
+    private String applyPlaceholders(String template, WebhookMessage message) {
+        return template
                 .replaceAll("%messageType%", message.messageType)
                 .replaceAll("%from%", message.senderPhoneNumber)
                 .replaceAll("%fromName%", message.senderName)
@@ -319,12 +319,16 @@ public class ForwardingConfig {
                         Matcher.quoteReplacement(message.getMmsFilename()));
     }
 
+    public String prepareMessage(WebhookMessage message) {
+        return applyPlaceholders(this.getTemplate(), message);
+    }
+
+    public String prepareHeaders(WebhookMessage message) {
+        return applyPlaceholders(this.getHeaders(), message);
+    }
+
     public String prepareAttachmentHeaders(WebhookMessage message) {
-        return this.getAttachmentHeaders()
-                .replaceAll("%mmsFilename%",
-                        Matcher.quoteReplacement(message.getMmsFilename()))
-                .replaceAll("%mmsAttachmentType%",
-                        Matcher.quoteReplacement(message.mmsAttachmentType));
+        return applyPlaceholders(this.getAttachmentHeaders(), message);
     }
 
     private static SharedPreferences getPreference(Context context) {

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
@@ -26,6 +26,10 @@ public class ForwardingConfig {
     private static final String KEY_IGNORE_SSL = "ignore_ssl";
     private static final String KEY_CHUNKED_MODE = "chunked_mode";
     private static final String KEY_IS_SMS_ENABLED = "is_sms_enabled";
+    private static final String KEY_ATTACHMENT_UPLOAD_ENABLED = "attachment_upload_enabled";
+    private static final String KEY_ATTACHMENT_URL = "attachment_url";
+    private static final String KEY_ATTACHMENT_METHOD = "attachment_method";
+    private static final String KEY_ATTACHMENT_HEADERS = "attachment_headers";
 
     private String key;
     private String sender;
@@ -37,6 +41,10 @@ public class ForwardingConfig {
     private boolean ignoreSsl = false;
     private boolean chunkedMode = true;
     private boolean isSmsEnabled = true;
+    private boolean attachmentUploadEnabled = false;
+    private String attachmentUrl = "";
+    private String attachmentMethod = "PUT";
+    private String attachmentHeaders = getDefaultAttachmentHeaders();
 
     public ForwardingConfig(Context context) {
         this.context = context;
@@ -122,12 +130,51 @@ public class ForwardingConfig {
         this.isSmsEnabled = isSmsEnabled;
     }
 
+    public boolean getAttachmentUploadEnabled() {
+        return this.attachmentUploadEnabled;
+    }
+
+    public void setAttachmentUploadEnabled(boolean attachmentUploadEnabled) {
+        this.attachmentUploadEnabled = attachmentUploadEnabled;
+    }
+
+    public String getAttachmentUrl() {
+        if (this.attachmentUrl == null || this.attachmentUrl.isEmpty()) {
+            return this.url;
+        }
+        return this.attachmentUrl;
+    }
+
+    public void setAttachmentUrl(String attachmentUrl) {
+        this.attachmentUrl = attachmentUrl;
+    }
+
+    public String getAttachmentMethod() {
+        return this.attachmentMethod;
+    }
+
+    public void setAttachmentMethod(String attachmentMethod) {
+        this.attachmentMethod = attachmentMethod;
+    }
+
+    public String getAttachmentHeaders() {
+        return this.attachmentHeaders;
+    }
+
+    public void setAttachmentHeaders(String attachmentHeaders) {
+        this.attachmentHeaders = attachmentHeaders;
+    }
+
     public static String getDefaultJsonTemplate() {
-        return "{\n  \"messageType\":\"%messageType%\",\n \"from\":\"%fromName%\",\n  \"text\":\"%text%\",\n  \"sentStamp\":%sentStamp%,\n  \"receivedStamp\":%receivedStamp%,\n  \"sim\":\"%sim%\",\n  \"mmsSubject\":\"%mmsSubject%\",\n  \"mmsAttachment\":\"%mmsAttachment%\",\n  \"mmsAttachmentType\":\"%mmsAttachmentType%\"\n}";
+        return "{\n  \"messageType\":\"%messageType%\",\n \"from\":\"%fromName%\",\n  \"text\":\"%text%\",\n  \"sentStamp\":%sentStamp%,\n  \"receivedStamp\":%receivedStamp%,\n  \"sim\":\"%sim%\",\n  \"mmsSubject\":\"%mmsSubject%\",\n  \"mmsAttachmentType\":\"%mmsAttachmentType%\"\n}";
     }
 
     public static String getDefaultJsonHeaders() {
         return "{\"User-agent\":\"SMS Forwarder App\"}";
+    }
+
+    public static String getDefaultAttachmentHeaders() {
+        return "{\"Filename\":\"%mmsFilename%\"}";
     }
 
     public static int getDefaultRetriesNumber() {
@@ -151,6 +198,10 @@ public class ForwardingConfig {
             json.put(KEY_IGNORE_SSL, this.ignoreSsl);
             json.put(KEY_CHUNKED_MODE, this.chunkedMode);
             json.put(KEY_IS_SMS_ENABLED, this.isSmsEnabled);
+            json.put(KEY_ATTACHMENT_UPLOAD_ENABLED, this.attachmentUploadEnabled);
+            json.put(KEY_ATTACHMENT_URL, this.attachmentUrl);
+            json.put(KEY_ATTACHMENT_METHOD, this.attachmentMethod);
+            json.put(KEY_ATTACHMENT_HEADERS, this.attachmentHeaders);
 
             SharedPreferences.Editor editor = getEditor(context);
             editor.putString(this.getKey(), json.toString());
@@ -214,6 +265,19 @@ public class ForwardingConfig {
                         config.setChunkedMode(json.getBoolean(KEY_CHUNKED_MODE));
                     } catch (JSONException ignored) {
                     }
+
+                    if (json.has(KEY_ATTACHMENT_UPLOAD_ENABLED)) {
+                        config.setAttachmentUploadEnabled(json.getBoolean(KEY_ATTACHMENT_UPLOAD_ENABLED));
+                    }
+                    if (json.has(KEY_ATTACHMENT_URL)) {
+                        config.setAttachmentUrl(json.getString(KEY_ATTACHMENT_URL));
+                    }
+                    if (json.has(KEY_ATTACHMENT_METHOD)) {
+                        config.setAttachmentMethod(json.getString(KEY_ATTACHMENT_METHOD));
+                    }
+                    if (json.has(KEY_ATTACHMENT_HEADERS)) {
+                        config.setAttachmentHeaders(json.getString(KEY_ATTACHMENT_HEADERS));
+                    }
                 } catch (JSONException e) {
                     Log.e("ForwardingConfig", e.getMessage());
                 }
@@ -247,8 +311,18 @@ public class ForwardingConfig {
                         Matcher.quoteReplacement(StringEscapeUtils.escapeJson(message.messageContent)))
                 .replaceAll("%mmsSubject%",
                         Matcher.quoteReplacement(StringEscapeUtils.escapeJson(message.mmsSubject)))
-                .replaceAll("%mmsAttachment%",
-                        Matcher.quoteReplacement(message.mmsAttachment))
+                .replaceAll("%mmsAttachmentB64%",
+                        Matcher.quoteReplacement(message.mmsAttachmentB64))
+                .replaceAll("%mmsAttachmentType%",
+                        Matcher.quoteReplacement(message.mmsAttachmentType))
+                .replaceAll("%mmsFilename%",
+                        Matcher.quoteReplacement(message.getMmsFilename()));
+    }
+
+    public String prepareAttachmentHeaders(WebhookMessage message) {
+        return this.getAttachmentHeaders()
+                .replaceAll("%mmsFilename%",
+                        Matcher.quoteReplacement(message.getMmsFilename()))
                 .replaceAll("%mmsAttachmentType%",
                         Matcher.quoteReplacement(message.mmsAttachmentType));
     }

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
@@ -123,7 +123,7 @@ public class ForwardingConfig {
     }
 
     public static String getDefaultJsonTemplate() {
-        return "{\n  \"messageType\":\"%messageType%\",\n \"from\":\"%fromName%\",\n  \"text\":\"%text%\",\n  \"sentStamp\":%sentStamp%,\n  \"receivedStamp\":%receivedStamp%,\n  \"sim\":\"%sim%\"\n}";
+        return "{\n  \"messageType\":\"%messageType%\",\n \"from\":\"%fromName%\",\n  \"text\":\"%text%\",\n  \"sentStamp\":%sentStamp%,\n  \"receivedStamp\":%receivedStamp%,\n  \"sim\":\"%sim%\",\n  \"mmsSubject\":\"%mmsSubject%\",\n  \"mmsAttachment\":\"%mmsAttachment%\",\n  \"mmsAttachmentType\":\"%mmsAttachmentType%\"\n}";
     }
 
     public static String getDefaultJsonHeaders() {
@@ -244,7 +244,13 @@ public class ForwardingConfig {
                 .replaceAll("%receivedStamp%", String.valueOf(System.currentTimeMillis()))
                 .replaceAll("%sim%", message.simSlotName)
                 .replaceAll("%text%",
-                        Matcher.quoteReplacement(StringEscapeUtils.escapeJson(message.messageContent)));
+                        Matcher.quoteReplacement(StringEscapeUtils.escapeJson(message.messageContent)))
+                .replaceAll("%mmsSubject%",
+                        Matcher.quoteReplacement(StringEscapeUtils.escapeJson(message.mmsSubject)))
+                .replaceAll("%mmsAttachment%",
+                        Matcher.quoteReplacement(message.mmsAttachment))
+                .replaceAll("%mmsAttachmentType%",
+                        Matcher.quoteReplacement(message.mmsAttachmentType));
     }
 
     private static SharedPreferences getPreference(Context context) {

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
@@ -12,7 +12,9 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.Toast;
 
@@ -64,6 +66,8 @@ public class ForwardingConfigDialog {
         chunkedModeCheckbox.setChecked(true);
 
         prepareSimSelector(context, view, 0);
+        prepareAttachmentFields(view, false, "", "PUT",
+                ForwardingConfig.getDefaultAttachmentHeaders());
 
         builder.setView(view);
         builder.setPositiveButton(R.string.btn_add, null);
@@ -119,6 +123,10 @@ public class ForwardingConfigDialog {
 
         final CheckBox chunkedModeCheckbox = view.findViewById(R.id.input_chunked_mode);
         chunkedModeCheckbox.setChecked(config.getChunkedMode());
+
+        prepareAttachmentFields(view, config.getAttachmentUploadEnabled(),
+                config.getAttachmentUrl(), config.getAttachmentMethod(),
+                config.getAttachmentHeaders());
 
         builder.setView(view);
         builder.setPositiveButton(R.string.btn_save, null);
@@ -211,7 +219,70 @@ public class ForwardingConfigDialog {
         config.setIgnoreSsl(ignoreSsl);
         config.setChunkedMode(chunkedMode);
 
+        // Attachment upload fields
+        final CheckBox attachmentCheckbox = view.findViewById(R.id.input_attachment_upload_enabled);
+        boolean attachmentEnabled = attachmentCheckbox.isChecked();
+        config.setAttachmentUploadEnabled(attachmentEnabled);
+
+        if (attachmentEnabled) {
+            final EditText attachmentUrlInput = view.findViewById(R.id.input_attachment_url);
+            String attachmentUrl = attachmentUrlInput.getText().toString();
+            if (TextUtils.isEmpty(attachmentUrl)) {
+                attachmentUrlInput.setError(context.getString(R.string.error_empty_attachment_url));
+                return null;
+            }
+            try {
+                new URL(attachmentUrl);
+            } catch (MalformedURLException e) {
+                attachmentUrlInput.setError(context.getString(R.string.error_wrong_attachment_url));
+                return null;
+            }
+            config.setAttachmentUrl(attachmentUrl);
+
+            Spinner methodSpinner = view.findViewById(R.id.input_attachment_method);
+            config.setAttachmentMethod((String) methodSpinner.getSelectedItem());
+
+            final EditText attachmentHeadersInput = view.findViewById(R.id.input_attachment_headers);
+            String attachmentHeaders = attachmentHeadersInput.getText().toString();
+            try {
+                new JSONObject(attachmentHeaders);
+            } catch (JSONException e) {
+                attachmentHeadersInput.setError(context.getString(R.string.error_wrong_json));
+                return null;
+            }
+            config.setAttachmentHeaders(attachmentHeaders);
+        }
+
         return config;
+    }
+
+    private void prepareAttachmentFields(View view, boolean enabled, String url,
+                                          String method, String headers) {
+        final CheckBox checkbox = view.findViewById(R.id.input_attachment_upload_enabled);
+        final LinearLayout container = view.findViewById(R.id.attachment_fields_container);
+
+        // Set up method spinner
+        Spinner methodSpinner = view.findViewById(R.id.input_attachment_method);
+        String[] methods = {"PUT", "POST"};
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(context,
+                android.R.layout.simple_spinner_item, methods);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        methodSpinner.setAdapter(adapter);
+        methodSpinner.setSelection("POST".equals(method) ? 1 : 0);
+
+        // Set up headers
+        final EditText headersInput = view.findViewById(R.id.input_attachment_headers);
+        headersInput.setText(headers);
+
+        // Set up URL
+        final EditText urlInput = view.findViewById(R.id.input_attachment_url);
+        urlInput.setText(url);
+
+        // Toggle visibility
+        checkbox.setChecked(enabled);
+        container.setVisibility(enabled ? View.VISIBLE : View.GONE);
+        checkbox.setOnCheckedChangeListener((buttonView, isChecked) ->
+                container.setVisibility(isChecked ? View.VISIBLE : View.GONE));
     }
 
     private void prepareSimSelector(Context context, View view, int selected) {
@@ -244,15 +315,32 @@ public class ForwardingConfigDialog {
         }
     }
 
+    private static final byte[] TEST_PNG = {
+            (byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+            0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x02, 0x00, 0x00, 0x00, (byte) 0x90, 0x77, 0x53,
+            (byte) 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+            0x54, 0x78, (byte) 0x9c, 0x63, (byte) 0xf8, (byte) 0xcf,
+            (byte) 0xc0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
+            (byte) 0xc9, (byte) 0xfe, (byte) 0x92, (byte) 0xef,
+            0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+            (byte) 0xae, 0x42, 0x60, (byte) 0x82
+    };
+
     private void testConfig(ForwardingConfig config) {
         if (config == null) {
             return;
         }
 
         Thread thread = new Thread(() -> {
-            String payload = config.prepareMessage(new WebhookMessage("test message type",
+            String b64 = android.util.Base64.encodeToString(TEST_PNG, android.util.Base64.NO_WRAP);
+            WebhookMessage testMessage = new WebhookMessage("test message type",
                     "123456789", "contact name", 1, "sim1", "test message", System.currentTimeMillis(),
-                    "test mms subject", "dGVzdCBhdHRhY2htZW50", "image/jpeg"));
+                    "test mms subject", b64, "image/png", TEST_PNG);
+
+            // 1. Send the normal templated text webhook
+            String payload = config.prepareMessage(testMessage);
             Request request = new Request(config.getUrl(), payload);
             request.setJsonHeaders(config.getHeaders());
             request.setIgnoreSsl(config.getIgnoreSsl());
@@ -260,7 +348,27 @@ public class ForwardingConfigDialog {
 
             String result = request.execute();
             if (!Objects.equals(result, Request.RESULT_SUCCESS)) {
-                result = Request.RESULT_ERROR;
+                Intent in = new Intent(BROADCAST_KEY);
+                in.putExtra(BROADCAST_KEY, Request.RESULT_ERROR);
+                context.sendBroadcast(in);
+                return;
+            }
+
+            // 2. Send binary attachment if enabled
+            if (config.getAttachmentUploadEnabled()) {
+                String headers = config.prepareAttachmentHeaders(testMessage);
+                BinaryRequest binReq = new BinaryRequest(
+                        config.getAttachmentUrl(),
+                        config.getAttachmentMethod(),
+                        TEST_PNG,
+                        "image/png");
+                binReq.setJsonHeaders(headers);
+                binReq.setIgnoreSsl(config.getIgnoreSsl());
+
+                result = binReq.execute();
+                if (!Objects.equals(result, BinaryRequest.RESULT_SUCCESS)) {
+                    result = BinaryRequest.RESULT_ERROR;
+                }
             }
 
             Intent in = new Intent(BROADCAST_KEY);

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
@@ -251,7 +251,8 @@ public class ForwardingConfigDialog {
 
         Thread thread = new Thread(() -> {
             String payload = config.prepareMessage(new WebhookMessage("test message type",
-                    "123456789", "contact name", 1, "sim1", "test message", System.currentTimeMillis()));
+                    "123456789", "contact name", 1, "sim1", "test message", System.currentTimeMillis(),
+                    "test mms subject", "dGVzdCBhdHRhY2htZW50", "image/jpeg"));
             Request request = new Request(config.getUrl(), payload);
             request.setJsonHeaders(config.getHeaders());
             request.setIgnoreSsl(config.getIgnoreSsl());

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
@@ -342,7 +342,7 @@ public class ForwardingConfigDialog {
             // send the normal templated text webhook
             String payload = config.prepareMessage(testMessage);
             Request request = new Request(config.getUrl(), payload);
-            request.setJsonHeaders(config.getHeaders());
+            request.setJsonHeaders(config.prepareHeaders(testMessage));
             request.setIgnoreSsl(config.getIgnoreSsl());
             request.setUseChunkedMode(config.getChunkedMode());
 

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
@@ -339,7 +339,7 @@ public class ForwardingConfigDialog {
                     "123456789", "contact name", 1, "sim1", "test message", System.currentTimeMillis(),
                     "test mms subject", b64, "image/png", TEST_PNG);
 
-            // 1. Send the normal templated text webhook
+            // send the normal templated text webhook
             String payload = config.prepareMessage(testMessage);
             Request request = new Request(config.getUrl(), payload);
             request.setJsonHeaders(config.getHeaders());
@@ -354,7 +354,7 @@ public class ForwardingConfigDialog {
                 return;
             }
 
-            // 2. Send binary attachment if enabled
+            // send binary attachment if enabled
             if (config.getAttachmentUploadEnabled()) {
                 String headers = config.prepareAttachmentHeaders(testMessage);
                 BinaryRequest binReq = new BinaryRequest(

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MainActivity.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MainActivity.java
@@ -41,11 +41,13 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECEIVE_SMS) != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECEIVE_SMS) != PackageManager.PERMISSION_GRANTED
+                || ContextCompat.checkSelfPermission(this, Manifest.permission.READ_SMS) != PackageManager.PERMISSION_GRANTED) {
             // we can run with any subset of these permissions,
             // but functionality will be limited
             ActivityCompat.requestPermissions(this, new String[]{
                     Manifest.permission.RECEIVE_SMS,
+                    Manifest.permission.READ_SMS,
                     Manifest.permission.READ_CONTACTS,
                     Manifest.permission.READ_PHONE_STATE,
                     Manifest.permission.READ_CALL_LOG

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MimeTypeHelper.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MimeTypeHelper.java
@@ -9,7 +9,7 @@ public class MimeTypeHelper {
             return "";
         }
         String ext = MimeTypeMap.getSingleton()
-                .getExtensionFromMimeType(mimeType.toLowerCase());
+                .getExtensionFromMimeType(mimeType.toLowerCase(java.util.Locale.ROOT));
         if (ext != null) {
             return "." + ext;
         }

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MimeTypeHelper.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MimeTypeHelper.java
@@ -1,0 +1,18 @@
+package org.scottmconway.incomingsmsgateway;
+
+import android.webkit.MimeTypeMap;
+
+public class MimeTypeHelper {
+
+    public static String getExtension(String mimeType) {
+        if (mimeType == null || mimeType.isEmpty()) {
+            return "";
+        }
+        String ext = MimeTypeMap.getSingleton()
+                .getExtensionFromMimeType(mimeType.toLowerCase());
+        if (ext != null) {
+            return "." + ext;
+        }
+        return "";
+    }
+}

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
@@ -82,9 +82,9 @@ public class MmsBroadcastReceiver extends ContentObserver {
         try {
             while (cursor.moveToNext()) {
                 long mmsId = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
-                int msgBox = cursor.getInt(cursor.getColumnIndex("msg_box"));
-                String subject = cursor.getString(cursor.getColumnIndex("sub"));
-                long date = cursor.getLong(cursor.getColumnIndex("date")) * 1000;
+                int msgBox = cursor.getInt(cursor.getColumnIndexOrThrow("msg_box"));
+                String subject = cursor.getString(cursor.getColumnIndexOrThrow("sub"));
+                long date = cursor.getLong(cursor.getColumnIndexOrThrow("date")) * 1000;
 
                 lastMmsId = mmsId;
 
@@ -279,8 +279,9 @@ public class MmsBroadcastReceiver extends ContentObserver {
             while (cursor.moveToNext()) {
                 MmsPart part = new MmsPart();
                 part.id = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
-                part.contentType = cursor.getString(cursor.getColumnIndex("ct"));
-                part.text = cursor.getString(cursor.getColumnIndex("text"));
+                part.contentType = cursor.getString(cursor.getColumnIndexOrThrow("ct"));
+                int textCol = cursor.getColumnIndex("text");
+                part.text = textCol >= 0 ? cursor.getString(textCol) : null;
 
                 if (part.contentType != null && !part.contentType.equals("text/plain")) {
                     part.data = readPartData(part.id);

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
@@ -24,6 +24,7 @@ public class MmsBroadcastReceiver extends ContentObserver {
     private static final String TAG = "MmsBroadcastReceiver";
     private static final Uri MMS_CONTENT_URI = Uri.parse("content://mms");
     private static final int MMS_ADDR_TYPE_FROM = 137;
+    private static final int MMS_ADDR_TYPE_TO = 151;
     private static final int MAX_READ_RETRIES = 3;
     private static final long[] RETRY_DELAYS_MS = {2000, 4000, 8000};
 
@@ -137,7 +138,7 @@ public class MmsBroadcastReceiver extends ContentObserver {
             ArrayList<MmsPart> attachments = new ArrayList<>();
             for (MmsPart part : parts) {
                 Log.d(TAG, "MMS " + mmsId + " part ct=" + part.contentType + " textLen=" + (part.text != null ? part.text.length() : 0) + " dataLen=" + (part.data != null ? part.data.length : 0));
-                if (part.contentType != null && part.contentType.startsWith("text/")) {
+                if (part.contentType != null && part.contentType.equals("text/plain")) {
                     if (part.text != null) {
                         textContent.append(part.text);
                     }
@@ -147,19 +148,21 @@ public class MmsBroadcastReceiver extends ContentObserver {
             }
 
             String senderName = getContactNameByPhoneNumber(sender, context);
+            ArrayList<String> recipients = getMmsRecipients(mmsId);
+            String displayName = formatGroupName(sender, senderName, recipients);
             String text = textContent.toString();
-            Log.d(TAG, "MMS " + mmsId + " text=" + text.length() + "chars, attachments=" + attachments.size());
+            Log.d(TAG, "MMS " + mmsId + " text=" + text.length() + "chars, attachments=" + attachments.size() + " recipients=" + recipients.size() + " displayName=" + displayName);
 
             if (attachments.isEmpty()) {
                 WebhookMessage message = new WebhookMessage(
-                        "Incoming MMS", sender, senderName, 0, "undetected",
+                        "Incoming MMS", sender, displayName, 0, "undetected",
                         text, date, subject, "", "", null);
                 dispatchToWebhooks(message);
             } else {
                 for (MmsPart attachment : attachments) {
                     String b64Data = Base64.encodeToString(attachment.data, Base64.NO_WRAP);
                     WebhookMessage message = new WebhookMessage(
-                            "Incoming MMS", sender, senderName, 0, "undetected",
+                            "Incoming MMS", sender, displayName, 0, "undetected",
                             text, date, subject, b64Data, attachment.contentType, attachment.data);
                     dispatchToWebhooks(message);
                 }
@@ -219,6 +222,64 @@ public class MmsBroadcastReceiver extends ContentObserver {
         return null;
     }
 
+    private ArrayList<String> getMmsRecipients(long mmsId) {
+        ArrayList<String> recipients = new ArrayList<>();
+        Uri addrUri = Uri.parse("content://mms/" + mmsId + "/addr");
+        ContentResolver resolver = context.getContentResolver();
+        Cursor cursor = resolver.query(addrUri,
+                new String[]{"address", "type"},
+                "type = " + MMS_ADDR_TYPE_TO,
+                null, null);
+
+        if (cursor == null) return recipients;
+
+        try {
+            while (cursor.moveToNext()) {
+                String addr = cursor.getString(cursor.getColumnIndexOrThrow("address"));
+                if (addr != null && !addr.isEmpty()) {
+                    recipients.add(addr);
+                }
+            }
+        } finally {
+            cursor.close();
+        }
+        return recipients;
+    }
+
+    private boolean isOwnNumber(String number) {
+        try {
+            android.telephony.TelephonyManager tm =
+                    (android.telephony.TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+            if (tm != null) {
+                String ownNumber = tm.getLine1Number();
+                if (ownNumber != null && !ownNumber.isEmpty()) {
+                    String norm1 = number.replaceAll("[^\\d+]", "");
+                    String norm2 = ownNumber.replaceAll("[^\\d+]", "");
+                    return norm1.endsWith(norm2) || norm2.endsWith(norm1);
+                }
+            }
+        } catch (SecurityException ignored) {}
+        // Also filter the generic "insert-address-token" placeholder Android uses
+        return "insert-address-token".equals(number);
+    }
+
+    private String formatGroupName(String sender, String senderName, ArrayList<String> recipients) {
+        if (recipients.isEmpty()) {
+            return senderName;
+        }
+
+        StringBuilder group = new StringBuilder();
+        group.append(senderName).append(" - ").append(senderName);
+
+        for (String recip : recipients) {
+            if (isOwnNumber(recip)) continue;
+            String recipName = getContactNameByPhoneNumber(recip, context);
+            group.append(", ").append(recipName);
+        }
+
+        return group.toString();
+    }
+
     private ArrayList<MmsPart> getMmsParts(long mmsId) {
         ArrayList<MmsPart> parts = new ArrayList<>();
         Uri partUri = Uri.parse("content://mms/" + mmsId + "/part");
@@ -236,7 +297,7 @@ public class MmsBroadcastReceiver extends ContentObserver {
                 part.contentType = cursor.getString(cursor.getColumnIndex("ct"));
                 part.text = cursor.getString(cursor.getColumnIndex("text"));
 
-                if (part.contentType != null && !part.contentType.startsWith("text/")) {
+                if (part.contentType != null && !part.contentType.equals("text/plain")) {
                     part.data = readPartData(part.id);
                 }
 

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
@@ -153,14 +153,14 @@ public class MmsBroadcastReceiver extends ContentObserver {
             if (attachments.isEmpty()) {
                 WebhookMessage message = new WebhookMessage(
                         "Incoming MMS", sender, senderName, 0, "undetected",
-                        text, date, subject, "", "");
+                        text, date, subject, "", "", null);
                 dispatchToWebhooks(message);
             } else {
                 for (MmsPart attachment : attachments) {
                     String b64Data = Base64.encodeToString(attachment.data, Base64.NO_WRAP);
                     WebhookMessage message = new WebhookMessage(
                             "Incoming MMS", sender, senderName, 0, "undetected",
-                            text, date, subject, b64Data, attachment.contentType);
+                            text, date, subject, b64Data, attachment.contentType, attachment.data);
                     dispatchToWebhooks(message);
                 }
             }
@@ -187,7 +187,15 @@ public class MmsBroadcastReceiver extends ContentObserver {
                 continue;
             }
 
+            // 1. Send the normal templated text webhook
             callWebHook(config, message);
+
+            // 2. Send raw binary attachment if enabled and data is present
+            if (config.getAttachmentUploadEnabled()
+                    && message.mmsAttachmentData != null
+                    && message.mmsAttachmentData.length > 0) {
+                callBinaryWebHook(config, message);
+            }
         }
     }
 
@@ -306,6 +314,39 @@ public class MmsBroadcastReceiver extends ContentObserver {
                 }
             }
             Log.w(TAG, "Webhook delivery failed after " + maxRetries + " retries");
+        }).start();
+    }
+
+    private void callBinaryWebHook(ForwardingConfig config, WebhookMessage message) {
+        String preparedHeaders = config.prepareAttachmentHeaders(message);
+        int maxRetries = config.getRetriesNumber();
+
+        new Thread(() -> {
+            for (int attempt = 0; attempt <= maxRetries; attempt++) {
+                BinaryRequest request = new BinaryRequest(
+                        config.getAttachmentUrl(),
+                        config.getAttachmentMethod(),
+                        message.mmsAttachmentData,
+                        message.mmsAttachmentType);
+                request.setJsonHeaders(preparedHeaders);
+                request.setIgnoreSsl(config.getIgnoreSsl());
+
+                String result = request.execute();
+                if (Objects.equals(result, BinaryRequest.RESULT_SUCCESS)) {
+                    Log.d(TAG, "Binary attachment uploaded successfully");
+                    return;
+                }
+                if (Objects.equals(result, BinaryRequest.RESULT_ERROR)) {
+                    Log.e(TAG, "Binary attachment upload failed permanently");
+                    return;
+                }
+                try {
+                    Thread.sleep((long) Math.pow(2, attempt) * 1000);
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+            Log.w(TAG, "Binary attachment delivery failed after " + maxRetries + " retries");
         }).start();
     }
 

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
@@ -341,7 +341,7 @@ public class MmsBroadcastReceiver extends ContentObserver {
         new Thread(() -> {
             for (int attempt = 0; attempt <= maxRetries; attempt++) {
                 Request request = new Request(config.getUrl(), strMessage);
-                request.setJsonHeaders(config.getHeaders());
+                request.setJsonHeaders(config.prepareHeaders(message));
                 request.setIgnoreSsl(config.getIgnoreSsl());
                 request.setUseChunkedMode(config.getChunkedMode());
 

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
@@ -48,16 +48,12 @@ public class MmsBroadcastReceiver extends ContentObserver {
     public void onChange(boolean selfChange) {
         super.onChange(selfChange);
 
-        boolean hasPerm = hasReadSmsPermission();
-        Log.d(TAG, "onChange: selfChange=" + selfChange + " hasPerm=" + hasPerm + " initialized=" + initialized + " lastMmsId=" + lastMmsId);
-
-        if (!hasPerm) {
+        if (!hasReadSmsPermission()) {
             return;
         }
         if (!initialized) {
             lastMmsId = getLatestMmsId();
             initialized = true;
-            Log.d(TAG, "Initialized lastMmsId=" + lastMmsId);
             return;
         }
         processNewMmsMessages();
@@ -69,7 +65,6 @@ public class MmsBroadcastReceiver extends ContentObserver {
     }
 
     private void processNewMmsMessages() {
-        Log.d(TAG, "processNewMmsMessages, lastMmsId=" + lastMmsId);
         ContentResolver resolver = context.getContentResolver();
         Cursor cursor = resolver.query(
                 MMS_CONTENT_URI,
@@ -85,20 +80,16 @@ public class MmsBroadcastReceiver extends ContentObserver {
         }
 
         try {
-            Log.d(TAG, "MMS query returned " + cursor.getCount() + " rows");
             while (cursor.moveToNext()) {
                 long mmsId = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
                 int msgBox = cursor.getInt(cursor.getColumnIndex("msg_box"));
                 String subject = cursor.getString(cursor.getColumnIndex("sub"));
                 long date = cursor.getLong(cursor.getColumnIndex("date")) * 1000;
 
-                Log.d(TAG, "MMS id=" + mmsId + " msg_box=" + msgBox + " sub=" + subject);
-
                 lastMmsId = mmsId;
 
                 // msg_box=1 is inbox (received messages)
                 if (msgBox != 1) {
-                    Log.d(TAG, "Skipping MMS " + mmsId + " (msg_box=" + msgBox + ", not inbox)");
                     continue;
                 }
 
@@ -113,11 +104,9 @@ public class MmsBroadcastReceiver extends ContentObserver {
 
     private void processMmsWithRetry(long mmsId, String subject, long date, int attempt) {
         long delay = attempt == 0 ? 2000 : RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
-        Log.d(TAG, "processMmsWithRetry id=" + mmsId + " attempt=" + attempt + " delay=" + delay);
 
         new Handler(context.getMainLooper()).postDelayed(() -> {
             String sender = getMmsSender(mmsId);
-            Log.d(TAG, "MMS " + mmsId + " sender=" + sender);
             if (sender == null && attempt < MAX_READ_RETRIES) {
                 processMmsWithRetry(mmsId, subject, date, attempt + 1);
                 return;
@@ -128,7 +117,6 @@ public class MmsBroadcastReceiver extends ContentObserver {
             }
 
             ArrayList<MmsPart> parts = getMmsParts(mmsId);
-            Log.d(TAG, "MMS " + mmsId + " parts=" + parts.size());
             if (parts.isEmpty() && attempt < MAX_READ_RETRIES) {
                 processMmsWithRetry(mmsId, subject, date, attempt + 1);
                 return;
@@ -137,7 +125,6 @@ public class MmsBroadcastReceiver extends ContentObserver {
             StringBuilder textContent = new StringBuilder();
             ArrayList<MmsPart> attachments = new ArrayList<>();
             for (MmsPart part : parts) {
-                Log.d(TAG, "MMS " + mmsId + " part ct=" + part.contentType + " textLen=" + (part.text != null ? part.text.length() : 0) + " dataLen=" + (part.data != null ? part.data.length : 0));
                 if (part.contentType != null && part.contentType.equals("text/plain")) {
                     if (part.text != null) {
                         textContent.append(part.text);
@@ -151,7 +138,6 @@ public class MmsBroadcastReceiver extends ContentObserver {
             ArrayList<String> recipients = getMmsRecipients(mmsId);
             String displayName = formatGroupName(sender, senderName, recipients);
             String text = textContent.toString();
-            Log.d(TAG, "MMS " + mmsId + " text=" + text.length() + "chars, attachments=" + attachments.size() + " recipients=" + recipients.size() + " displayName=" + displayName);
 
             if (attachments.isEmpty()) {
                 WebhookMessage message = new WebhookMessage(
@@ -173,7 +159,6 @@ public class MmsBroadcastReceiver extends ContentObserver {
     private void dispatchToWebhooks(WebhookMessage message) {
         ArrayList<ForwardingConfig> configs = ForwardingConfig.getAll(context);
         String asterisk = context.getString(R.string.asterisk);
-        Log.d(TAG, "dispatchToWebhooks: " + configs.size() + " configs, sender=" + message.senderPhoneNumber + " type=" + message.messageType);
 
         for (ForwardingConfig config : configs) {
             if ((message.senderPhoneNumber == null ||
@@ -394,11 +379,9 @@ public class MmsBroadcastReceiver extends ContentObserver {
 
                 String result = request.execute();
                 if (Objects.equals(result, BinaryRequest.RESULT_SUCCESS)) {
-                    Log.d(TAG, "Binary attachment uploaded successfully");
                     return;
                 }
                 if (Objects.equals(result, BinaryRequest.RESULT_ERROR)) {
-                    Log.e(TAG, "Binary attachment upload failed permanently");
                     return;
                 }
                 try {

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
@@ -1,0 +1,340 @@
+package org.scottmconway.incomingsmsgateway;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Handler;
+import android.provider.ContactsContract;
+import android.util.Base64;
+import android.util.Log;
+
+import androidx.core.content.ContextCompat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Objects;
+
+public class MmsBroadcastReceiver extends ContentObserver {
+
+    private static final String TAG = "MmsBroadcastReceiver";
+    private static final Uri MMS_CONTENT_URI = Uri.parse("content://mms");
+    private static final int MMS_ADDR_TYPE_FROM = 137;
+    private static final int MAX_READ_RETRIES = 3;
+    private static final long[] RETRY_DELAYS_MS = {2000, 4000, 8000};
+
+    private final Context context;
+    private long lastMmsId;
+    private boolean initialized;
+
+    public MmsBroadcastReceiver(Handler handler, Context context) {
+        super(handler);
+        this.context = context;
+        if (hasReadSmsPermission()) {
+            this.lastMmsId = getLatestMmsId();
+            this.initialized = true;
+        } else {
+            this.lastMmsId = 0;
+            this.initialized = false;
+        }
+    }
+
+    @Override
+    public void onChange(boolean selfChange) {
+        super.onChange(selfChange);
+
+        boolean hasPerm = hasReadSmsPermission();
+        Log.d(TAG, "onChange: selfChange=" + selfChange + " hasPerm=" + hasPerm + " initialized=" + initialized + " lastMmsId=" + lastMmsId);
+
+        if (!hasPerm) {
+            return;
+        }
+        if (!initialized) {
+            lastMmsId = getLatestMmsId();
+            initialized = true;
+            Log.d(TAG, "Initialized lastMmsId=" + lastMmsId);
+            return;
+        }
+        processNewMmsMessages();
+    }
+
+    private boolean hasReadSmsPermission() {
+        return ContextCompat.checkSelfPermission(context, android.Manifest.permission.READ_SMS)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void processNewMmsMessages() {
+        Log.d(TAG, "processNewMmsMessages, lastMmsId=" + lastMmsId);
+        ContentResolver resolver = context.getContentResolver();
+        Cursor cursor = resolver.query(
+                MMS_CONTENT_URI,
+                new String[]{"_id", "sub", "date", "msg_box"},
+                "_id > ?",
+                new String[]{String.valueOf(lastMmsId)},
+                "_id ASC"
+        );
+
+        if (cursor == null) {
+            Log.w(TAG, "MMS query returned null cursor");
+            return;
+        }
+
+        try {
+            Log.d(TAG, "MMS query returned " + cursor.getCount() + " rows");
+            while (cursor.moveToNext()) {
+                long mmsId = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
+                int msgBox = cursor.getInt(cursor.getColumnIndex("msg_box"));
+                String subject = cursor.getString(cursor.getColumnIndex("sub"));
+                long date = cursor.getLong(cursor.getColumnIndex("date")) * 1000;
+
+                Log.d(TAG, "MMS id=" + mmsId + " msg_box=" + msgBox + " sub=" + subject);
+
+                lastMmsId = mmsId;
+
+                // msg_box=1 is inbox (received messages)
+                if (msgBox != 1) {
+                    Log.d(TAG, "Skipping MMS " + mmsId + " (msg_box=" + msgBox + ", not inbox)");
+                    continue;
+                }
+
+                if (subject == null) subject = "";
+
+                processMmsWithRetry(mmsId, subject, date, 0);
+            }
+        } finally {
+            cursor.close();
+        }
+    }
+
+    private void processMmsWithRetry(long mmsId, String subject, long date, int attempt) {
+        long delay = attempt == 0 ? 2000 : RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+        Log.d(TAG, "processMmsWithRetry id=" + mmsId + " attempt=" + attempt + " delay=" + delay);
+
+        new Handler(context.getMainLooper()).postDelayed(() -> {
+            String sender = getMmsSender(mmsId);
+            Log.d(TAG, "MMS " + mmsId + " sender=" + sender);
+            if (sender == null && attempt < MAX_READ_RETRIES) {
+                processMmsWithRetry(mmsId, subject, date, attempt + 1);
+                return;
+            }
+            if (sender == null) {
+                Log.w(TAG, "Could not read sender for MMS " + mmsId + " after retries");
+                return;
+            }
+
+            ArrayList<MmsPart> parts = getMmsParts(mmsId);
+            Log.d(TAG, "MMS " + mmsId + " parts=" + parts.size());
+            if (parts.isEmpty() && attempt < MAX_READ_RETRIES) {
+                processMmsWithRetry(mmsId, subject, date, attempt + 1);
+                return;
+            }
+
+            StringBuilder textContent = new StringBuilder();
+            ArrayList<MmsPart> attachments = new ArrayList<>();
+            for (MmsPart part : parts) {
+                Log.d(TAG, "MMS " + mmsId + " part ct=" + part.contentType + " textLen=" + (part.text != null ? part.text.length() : 0) + " dataLen=" + (part.data != null ? part.data.length : 0));
+                if (part.contentType != null && part.contentType.startsWith("text/")) {
+                    if (part.text != null) {
+                        textContent.append(part.text);
+                    }
+                } else if (part.data != null && part.data.length > 0) {
+                    attachments.add(part);
+                }
+            }
+
+            String senderName = getContactNameByPhoneNumber(sender, context);
+            String text = textContent.toString();
+            Log.d(TAG, "MMS " + mmsId + " text=" + text.length() + "chars, attachments=" + attachments.size());
+
+            if (attachments.isEmpty()) {
+                WebhookMessage message = new WebhookMessage(
+                        "Incoming MMS", sender, senderName, 0, "undetected",
+                        text, date, subject, "", "");
+                dispatchToWebhooks(message);
+            } else {
+                for (MmsPart attachment : attachments) {
+                    String b64Data = Base64.encodeToString(attachment.data, Base64.NO_WRAP);
+                    WebhookMessage message = new WebhookMessage(
+                            "Incoming MMS", sender, senderName, 0, "undetected",
+                            text, date, subject, b64Data, attachment.contentType);
+                    dispatchToWebhooks(message);
+                }
+            }
+        }, delay);
+    }
+
+    private void dispatchToWebhooks(WebhookMessage message) {
+        ArrayList<ForwardingConfig> configs = ForwardingConfig.getAll(context);
+        String asterisk = context.getString(R.string.asterisk);
+        Log.d(TAG, "dispatchToWebhooks: " + configs.size() + " configs, sender=" + message.senderPhoneNumber + " type=" + message.messageType);
+
+        for (ForwardingConfig config : configs) {
+            if ((message.senderPhoneNumber == null ||
+                    !message.senderPhoneNumber.equals(config.getSender())) &&
+                    !config.getSender().equals(asterisk)) {
+                continue;
+            }
+
+            if (!config.getIsSmsEnabled()) {
+                continue;
+            }
+
+            if (config.getSimSlot() > 0 && config.getSimSlot() != message.simSlotId) {
+                continue;
+            }
+
+            callWebHook(config, message);
+        }
+    }
+
+    private String getMmsSender(long mmsId) {
+        Uri addrUri = Uri.parse("content://mms/" + mmsId + "/addr");
+        ContentResolver resolver = context.getContentResolver();
+        Cursor cursor = resolver.query(addrUri,
+                new String[]{"address", "type"},
+                "type = " + MMS_ADDR_TYPE_FROM,
+                null, null);
+
+        if (cursor == null) return null;
+
+        try {
+            if (cursor.moveToFirst()) {
+                return cursor.getString(cursor.getColumnIndexOrThrow("address"));
+            }
+        } finally {
+            cursor.close();
+        }
+        return null;
+    }
+
+    private ArrayList<MmsPart> getMmsParts(long mmsId) {
+        ArrayList<MmsPart> parts = new ArrayList<>();
+        Uri partUri = Uri.parse("content://mms/" + mmsId + "/part");
+        ContentResolver resolver = context.getContentResolver();
+        Cursor cursor = resolver.query(partUri,
+                new String[]{"_id", "ct", "text", "_data"},
+                null, null, null);
+
+        if (cursor == null) return parts;
+
+        try {
+            while (cursor.moveToNext()) {
+                MmsPart part = new MmsPart();
+                part.id = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
+                part.contentType = cursor.getString(cursor.getColumnIndex("ct"));
+                part.text = cursor.getString(cursor.getColumnIndex("text"));
+
+                if (part.contentType != null && !part.contentType.startsWith("text/")) {
+                    part.data = readPartData(part.id);
+                }
+
+                parts.add(part);
+            }
+        } finally {
+            cursor.close();
+        }
+        return parts;
+    }
+
+    private byte[] readPartData(long partId) {
+        Uri partUri = Uri.parse("content://mms/part/" + partId);
+        try (InputStream is = context.getContentResolver().openInputStream(partUri)) {
+            if (is == null) return new byte[0];
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = is.read(chunk)) != -1) {
+                buffer.write(chunk, 0, bytesRead);
+            }
+            return buffer.toByteArray();
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to read MMS part data: " + e.getMessage());
+            return new byte[0];
+        }
+    }
+
+    private long getLatestMmsId() {
+        ContentResolver resolver = context.getContentResolver();
+        Cursor cursor = resolver.query(MMS_CONTENT_URI,
+                new String[]{"_id"},
+                null, null, "_id DESC");
+
+        if (cursor == null) return 0;
+
+        try {
+            if (cursor.moveToFirst()) {
+                return cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
+            }
+        } finally {
+            cursor.close();
+        }
+        return 0;
+    }
+
+    /**
+     * Sends the webhook via a background thread with manual retry and exponential backoff.
+     * We avoid WorkManager here because its Data object has a ~10KB size limit,
+     * which base64-encoded MMS attachments will easily exceed.
+     */
+    private void callWebHook(ForwardingConfig config, WebhookMessage message) {
+        String strMessage = config.prepareMessage(message);
+        int maxRetries = config.getRetriesNumber();
+
+        new Thread(() -> {
+            for (int attempt = 0; attempt <= maxRetries; attempt++) {
+                Request request = new Request(config.getUrl(), strMessage);
+                request.setJsonHeaders(config.getHeaders());
+                request.setIgnoreSsl(config.getIgnoreSsl());
+                request.setUseChunkedMode(config.getChunkedMode());
+
+                String result = request.execute();
+                if (Objects.equals(result, Request.RESULT_SUCCESS)) {
+                    return;
+                }
+                if (Objects.equals(result, Request.RESULT_ERROR)) {
+                    return;
+                }
+                // RESULT_RETRY: wait with exponential backoff
+                try {
+                    Thread.sleep((long) Math.pow(2, attempt) * 1000);
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+            Log.w(TAG, "Webhook delivery failed after " + maxRetries + " retries");
+        }).start();
+    }
+
+    private static String getContactNameByPhoneNumber(String phoneNumber, Context context) {
+        if (ContextCompat.checkSelfPermission(context, android.Manifest.permission.READ_CONTACTS)
+                == PackageManager.PERMISSION_GRANTED) {
+            try {
+                ContentResolver contentResolver = context.getContentResolver();
+                Uri uri = Uri.withAppendedPath(
+                        ContactsContract.PhoneLookup.CONTENT_FILTER_URI, Uri.encode(phoneNumber));
+                String[] projection = {ContactsContract.PhoneLookup.DISPLAY_NAME};
+                Cursor cursor = contentResolver.query(uri, projection, null, null, null);
+                if (cursor != null && cursor.moveToFirst()) {
+                    int nameIndex = cursor.getColumnIndex(ContactsContract.PhoneLookup.DISPLAY_NAME);
+                    String contactName = cursor.getString(nameIndex);
+                    cursor.close();
+                    if (contactName != null) return contactName;
+                }
+            } catch (java.lang.SecurityException se) {
+                Log.w(TAG, "READ_CONTACTS permission not granted");
+            }
+        }
+        return phoneNumber;
+    }
+
+    private static class MmsPart {
+        long id;
+        String contentType;
+        String text;
+        byte[] data;
+    }
+}

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/Request.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/Request.java
@@ -8,7 +8,6 @@ import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -138,7 +137,7 @@ public class Request {
             out.close();
 
             int responseCode = this.connection.getResponseCode();
-            if (responseCode / 100 != 2) {
+            if (responseCode >= 400) {
                 Log.e("SmsGateway", "webhook failed: HTTP " + responseCode);
                 result = RESULT_RETRY;
             }

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/Request.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/Request.java
@@ -137,10 +137,9 @@ public class Request {
             writer.close();
             out.close();
 
-            new BufferedInputStream(this.connection.getInputStream());
-
-            char code = Integer.toString(this.connection.getResponseCode()).charAt(0);
-            if (!Character.toString(code).equals("2")) {
+            int responseCode = this.connection.getResponseCode();
+            if (responseCode / 100 != 2) {
+                Log.e("SmsGateway", "webhook failed: HTTP " + responseCode);
                 result = RESULT_RETRY;
             }
         } catch (NoSuchAlgorithmException e) {

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/SmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/SmsBroadcastReceiver.java
@@ -176,7 +176,7 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
         Data data = new Data.Builder()
                 .putString(RequestWorker.DATA_URL, config.getUrl())
                 .putString(RequestWorker.DATA_TEXT, strMessage)
-                .putString(RequestWorker.DATA_HEADERS, config.getHeaders())
+                .putString(RequestWorker.DATA_HEADERS, config.prepareHeaders(message))
                 .putBoolean(RequestWorker.DATA_IGNORE_SSL, config.getIgnoreSsl())
                 .putBoolean(RequestWorker.DATA_CHUNKED_MODE, config.getChunkedMode())
                 .putInt(RequestWorker.DATA_MAX_RETRIES, config.getRetriesNumber())

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/SmsReceiverService.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/SmsReceiverService.java
@@ -7,7 +7,10 @@ import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.database.ContentObserver;
+import android.net.Uri;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
 import android.provider.Telephony;
 import android.telephony.TelephonyManager;
@@ -17,6 +20,7 @@ import androidx.annotation.Nullable;
 public class SmsReceiverService extends Service {
 
     BroadcastReceiver receiver;
+    ContentObserver mmsObserver;
 
     private static final String CHANNEL_ID = "SmsDefault";
 
@@ -39,6 +43,15 @@ public class SmsReceiverService extends Service {
         }
 
         registerReceiver(receiver, filter);
+
+        // Register MMS ContentObserver on both URIs since different Android
+        // implementations notify on different content URIs for incoming MMS
+        Handler handler = new Handler(getMainLooper());
+        mmsObserver = new MmsBroadcastReceiver(handler, getApplicationContext());
+        getContentResolver().registerContentObserver(
+                Uri.parse("content://mms"), true, mmsObserver);
+        getContentResolver().registerContentObserver(
+                Uri.parse("content://mms-sms"), true, mmsObserver);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationManager notificationManager = getSystemService(NotificationManager.class);
@@ -66,6 +79,7 @@ public class SmsReceiverService extends Service {
         super.onDestroy();
 
         unregisterReceiver(receiver);
+        getContentResolver().unregisterContentObserver(mmsObserver);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             stopForeground(true);

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/WebhookMessage.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/WebhookMessage.java
@@ -8,16 +8,24 @@ public class WebhookMessage {
     public String simSlotName;
     public String messageContent;
     public long timestamp;
+    public String mmsSubject;
+    public String mmsAttachment;
+    public String mmsAttachmentType;
 
-
-    // Parameterized constructor
     public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp) {
+        this(messageType, senderPhoneNumber, senderName, simSlotId, simSlotName, messageContent, timestamp, "", "", "");
+    }
+
+    public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp, String mmsSubject, String mmsAttachment, String mmsAttachmentType) {
         this.messageType = messageType;
         this.senderName = senderName;
         this.simSlotId = simSlotId;
         this.simSlotName = simSlotName;
         this.messageContent = messageContent;
         this.timestamp = timestamp;
+        this.mmsSubject = mmsSubject != null ? mmsSubject : "";
+        this.mmsAttachment = mmsAttachment != null ? mmsAttachment : "";
+        this.mmsAttachmentType = mmsAttachmentType != null ? mmsAttachmentType : "";
 
         if (senderPhoneNumber == null) {
             this.senderPhoneNumber = "";

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/WebhookMessage.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/WebhookMessage.java
@@ -9,14 +9,19 @@ public class WebhookMessage {
     public String messageContent;
     public long timestamp;
     public String mmsSubject;
-    public String mmsAttachment;
+    public String mmsAttachmentB64;
     public String mmsAttachmentType;
+    public byte[] mmsAttachmentData;
 
     public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp) {
-        this(messageType, senderPhoneNumber, senderName, simSlotId, simSlotName, messageContent, timestamp, "", "", "");
+        this(messageType, senderPhoneNumber, senderName, simSlotId, simSlotName, messageContent, timestamp, "", "", "", null);
     }
 
-    public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp, String mmsSubject, String mmsAttachment, String mmsAttachmentType) {
+    public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp, String mmsSubject, String mmsAttachmentB64, String mmsAttachmentType) {
+        this(messageType, senderPhoneNumber, senderName, simSlotId, simSlotName, messageContent, timestamp, mmsSubject, mmsAttachmentB64, mmsAttachmentType, null);
+    }
+
+    public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp, String mmsSubject, String mmsAttachmentB64, String mmsAttachmentType, byte[] mmsAttachmentData) {
         this.messageType = messageType;
         this.senderName = senderName;
         this.simSlotId = simSlotId;
@@ -24,12 +29,17 @@ public class WebhookMessage {
         this.messageContent = messageContent;
         this.timestamp = timestamp;
         this.mmsSubject = mmsSubject != null ? mmsSubject : "";
-        this.mmsAttachment = mmsAttachment != null ? mmsAttachment : "";
+        this.mmsAttachmentB64 = mmsAttachmentB64 != null ? mmsAttachmentB64 : "";
         this.mmsAttachmentType = mmsAttachmentType != null ? mmsAttachmentType : "";
+        this.mmsAttachmentData = mmsAttachmentData;
 
         if (senderPhoneNumber == null) {
             this.senderPhoneNumber = "";
         }
         else this.senderPhoneNumber = senderPhoneNumber;
+    }
+
+    public String getMmsFilename() {
+        return "attachment" + MimeTypeHelper.getExtension(mmsAttachmentType);
     }
 }

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/WebhookMessage.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/WebhookMessage.java
@@ -17,10 +17,6 @@ public class WebhookMessage {
         this(messageType, senderPhoneNumber, senderName, simSlotId, simSlotName, messageContent, timestamp, "", "", "", null);
     }
 
-    public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp, String mmsSubject, String mmsAttachmentB64, String mmsAttachmentType) {
-        this(messageType, senderPhoneNumber, senderName, simSlotId, simSlotName, messageContent, timestamp, mmsSubject, mmsAttachmentB64, mmsAttachmentType, null);
-    }
-
     public WebhookMessage(String messageType, String senderPhoneNumber, String senderName, int simSlotId, String simSlotName, String messageContent, long timestamp, String mmsSubject, String mmsAttachmentB64, String mmsAttachmentType, byte[] mmsAttachmentData) {
         this.messageType = messageType;
         this.senderName = senderName;

--- a/app/src/main/res/layout/dialog_config_edit_form.xml
+++ b/app/src/main/res/layout/dialog_config_edit_form.xml
@@ -231,5 +231,122 @@
                 android:layout_marginRight="20dp" />
 
         </RelativeLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginLeft="12dp"
+            android:layout_marginTop="24dp"
+            android:textColor="@color/colorBlack"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:text="@string/label_attachment_section" />
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_marginStart="12dp"
+                android:layout_marginLeft="12dp"
+                android:layout_marginTop="16dp"
+                android:labelFor="@+id/input_attachment_upload_enabled"
+                android:text="@string/label_attachment_upload_enabled" />
+
+            <CheckBox
+                android:id="@+id/input_attachment_upload_enabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_marginStart="12dp"
+                android:layout_marginLeft="12dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginRight="20dp" />
+
+        </RelativeLayout>
+
+        <LinearLayout
+            android:id="@+id/attachment_fields_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginLeft="12dp"
+                android:layout_marginTop="16dp"
+                android:labelFor="@+id/input_attachment_url"
+                android:text="@string/label_attachment_url" />
+
+            <EditText
+                android:id="@+id/input_attachment_url"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:hint="@string/input_url"
+                android:inputType="textUri" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginLeft="12dp"
+                android:layout_marginTop="16dp"
+                android:labelFor="@+id/input_attachment_method"
+                android:text="@string/label_attachment_method" />
+
+            <Spinner
+                android:id="@+id/input_attachment_method"
+                android:layout_width="fill_parent"
+                android:layout_marginStart="5dp"
+                android:layout_marginLeft="5dp"
+                android:popupTheme="@style/AppTheme.Spinner"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginLeft="12dp"
+                android:layout_marginTop="16dp"
+                android:labelFor="@+id/input_attachment_headers"
+                android:text="@string/label_attachment_headers" />
+
+            <EditText
+                android:id="@+id/input_attachment_headers"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:layout_marginBottom="4dp"
+                android:inputType="textMultiLine"
+                android:maxLines="5"
+                android:textSize="11sp"
+                android:typeface="monospace" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_marginLeft="12dp"
+                android:layout_marginTop="-4dp"
+                android:text="@string/attachment_headers_recommendation"
+                android:textSize="11sp" />
+
+        </LinearLayout>
+
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_config_edit_form.xml
+++ b/app/src/main/res/layout/dialog_config_edit_form.xml
@@ -3,7 +3,7 @@
     android:layout_height="match_parent"
     android:fadeScrollbars="false">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         android:id="@+id/dialog_config_edit_form"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -250,6 +250,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_marginStart="12dp"
                 android:layout_marginLeft="12dp"
@@ -261,6 +262,7 @@
                 android:id="@+id/input_attachment_upload_enabled"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"
                 android:layout_marginStart="12dp"
                 android:layout_marginLeft="12dp"
@@ -295,6 +297,7 @@
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
                 android:hint="@string/input_url"
+                android:importantForAutofill="no"
                 android:inputType="textUri" />
 
             <TextView
@@ -332,6 +335,7 @@
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
                 android:layout_marginBottom="4dp"
+                android:importantForAutofill="no"
                 android:inputType="textMultiLine"
                 android:maxLines="5"
                 android:textSize="11sp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="label_chunked_mode">Chunked Mode (vs Fixed Length)</string>
     <string name="hint_sender">number or text</string>
     <string name="sender_recommendation">Use * symbol to catch any SMS</string>
-    <string name="json_template_recommendation">Available placeholders %text%, %from%, %fromName%, %messageType%, %sentStamp%, %receivedStamp%, %sim%</string>
+    <string name="json_template_recommendation">Available placeholders %text%, %from%, %fromName%, %messageType%, %sentStamp%, %receivedStamp%, %sim%, %mmsSubject%, %mmsAttachment%, %mmsAttachmentType%</string>
     <string name="error_empty_sender">Empty sender</string>
     <string name="error_empty_url">Empty URL</string>
     <string name="error_wrong_url">Wrong URL</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,15 @@
     <string name="label_chunked_mode">Chunked Mode (vs Fixed Length)</string>
     <string name="hint_sender">number or text</string>
     <string name="sender_recommendation">Use * symbol to catch any SMS</string>
-    <string name="json_template_recommendation">Available placeholders %text%, %from%, %fromName%, %messageType%, %sentStamp%, %receivedStamp%, %sim%, %mmsSubject%, %mmsAttachment%, %mmsAttachmentType%</string>
+    <string name="json_template_recommendation">Available placeholders %text%, %from%, %fromName%, %messageType%, %sentStamp%, %receivedStamp%, %sim%, %mmsSubject%, %mmsAttachmentB64%, %mmsAttachmentType%</string>
+    <string name="label_attachment_section">MMS Attachment Upload</string>
+    <string name="label_attachment_upload_enabled">Send attachment as separate request</string>
+    <string name="label_attachment_url">Attachment Upload URL</string>
+    <string name="label_attachment_method">HTTP Method</string>
+    <string name="label_attachment_headers">Attachment Headers</string>
+    <string name="attachment_headers_recommendation">Available placeholders %mmsFilename%, %mmsAttachmentType%</string>
+    <string name="error_empty_attachment_url">Empty attachment URL</string>
+    <string name="error_wrong_attachment_url">Invalid attachment URL</string>
     <string name="error_empty_sender">Empty sender</string>
     <string name="error_empty_url">Empty URL</string>
     <string name="error_wrong_url">Wrong URL</string>


### PR DESCRIPTION
Adds support for alerting on text and multimedia MMS messages.

Each attachment creates a new message, with %mmsAttachmentB64% containing the attachment as a base64-encoded string. If enabled, a second HTTP request (PUT or POST) will be made to an endpoint to upload the attachment, with the body being the attachment's binary.