### PR TITLE
Request method & placeholders in url

### DIFF
--- a/app/src/androidTest/java/org/scottmconway/incomingsmsgateway/SmsReceiverTest.java
+++ b/app/src/androidTest/java/org/scottmconway/incomingsmsgateway/SmsReceiverTest.java
@@ -33,10 +33,7 @@ public class SmsReceiverTest {
         Mockito.verify(receiver, Mockito.times(0))
                 .callWebHook(
                         Mockito.any(ForwardingConfig.class),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyLong()
+                        Mockito.any(WebhookMessage.class)
                 );
     }
 
@@ -49,10 +46,7 @@ public class SmsReceiverTest {
         Mockito.verify(receiver, Mockito.times(1))
                 .callWebHook(
                         Mockito.any(ForwardingConfig.class),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyLong()
+                        Mockito.any(WebhookMessage.class)
                 );
     }
 
@@ -65,10 +59,7 @@ public class SmsReceiverTest {
         Mockito.verify(receiver, Mockito.times(1))
                 .callWebHook(
                         Mockito.any(ForwardingConfig.class),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyLong()
+                        Mockito.any(WebhookMessage.class)
                 );
     }
 
@@ -81,10 +72,7 @@ public class SmsReceiverTest {
         Mockito.verify(receiver, Mockito.times(0))
                 .callWebHook(
                         Mockito.any(ForwardingConfig.class),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyLong()
+                        Mockito.any(WebhookMessage.class)
                 );
     }
 
@@ -97,10 +85,7 @@ public class SmsReceiverTest {
         Mockito.verify(receiver, Mockito.times(1))
                 .callWebHook(
                         Mockito.any(ForwardingConfig.class),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyLong()
+                        Mockito.any(WebhookMessage.class)
                 );
     }
 
@@ -137,10 +122,7 @@ public class SmsReceiverTest {
         Mockito.doNothing().when(receiver)
                 .callWebHook(
                         Mockito.any(ForwardingConfig.class),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyString(),
-                        Mockito.anyLong()
+                        Mockito.any(WebhookMessage.class)
                 );
 
         return receiver;

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfig.java
@@ -11,7 +11,6 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Random;
-import java.util.regex.Matcher;
 
 public class ForwardingConfig {
     final private Context context;
@@ -30,6 +29,7 @@ public class ForwardingConfig {
     private static final String KEY_ATTACHMENT_URL = "attachment_url";
     private static final String KEY_ATTACHMENT_METHOD = "attachment_method";
     private static final String KEY_ATTACHMENT_HEADERS = "attachment_headers";
+    private static final String KEY_REQUEST_METHOD = "request_method";
 
     private String key;
     private String sender;
@@ -43,6 +43,7 @@ public class ForwardingConfig {
     private boolean isSmsEnabled = true;
     private boolean attachmentUploadEnabled = false;
     private String attachmentUrl = "";
+    private String requestMethod = "POST";
     private String attachmentMethod = "PUT";
     private String attachmentHeaders = getDefaultAttachmentHeaders();
 
@@ -122,6 +123,14 @@ public class ForwardingConfig {
         this.chunkedMode = chunkedMode;
     }
 
+    public String getRequestMethod() {
+        return this.requestMethod;
+    }
+
+    public void setRequestMethod(String requestMethod) {
+        this.requestMethod = requestMethod;
+    }
+
     public boolean getIsSmsEnabled() {
         return this.isSmsEnabled;
     }
@@ -197,6 +206,7 @@ public class ForwardingConfig {
             json.put(KEY_RETRIES_NUMBER, this.retriesNumber);
             json.put(KEY_IGNORE_SSL, this.ignoreSsl);
             json.put(KEY_CHUNKED_MODE, this.chunkedMode);
+            json.put(KEY_REQUEST_METHOD, this.requestMethod);
             json.put(KEY_IS_SMS_ENABLED, this.isSmsEnabled);
             json.put(KEY_ATTACHMENT_UPLOAD_ENABLED, this.attachmentUploadEnabled);
             json.put(KEY_ATTACHMENT_URL, this.attachmentUrl);
@@ -266,6 +276,10 @@ public class ForwardingConfig {
                     } catch (JSONException ignored) {
                     }
 
+                    if (json.has(KEY_REQUEST_METHOD)) {
+                        config.setRequestMethod(json.getString(KEY_REQUEST_METHOD));
+                    }
+
                     if (json.has(KEY_ATTACHMENT_UPLOAD_ENABLED)) {
                         config.setAttachmentUploadEnabled(json.getBoolean(KEY_ATTACHMENT_UPLOAD_ENABLED));
                     }
@@ -301,22 +315,18 @@ public class ForwardingConfig {
 
     private String applyPlaceholders(String template, WebhookMessage message) {
         return template
-                .replaceAll("%messageType%", message.messageType)
-                .replaceAll("%from%", message.senderPhoneNumber)
-                .replaceAll("%fromName%", message.senderName)
-                .replaceAll("%sentStamp%", String.valueOf(message.timestamp))
-                .replaceAll("%receivedStamp%", String.valueOf(System.currentTimeMillis()))
-                .replaceAll("%sim%", message.simSlotName)
-                .replaceAll("%text%",
-                        Matcher.quoteReplacement(StringEscapeUtils.escapeJson(message.messageContent)))
-                .replaceAll("%mmsSubject%",
-                        Matcher.quoteReplacement(StringEscapeUtils.escapeJson(message.mmsSubject)))
-                .replaceAll("%mmsAttachmentB64%",
-                        Matcher.quoteReplacement(message.mmsAttachmentB64))
-                .replaceAll("%mmsAttachmentType%",
-                        Matcher.quoteReplacement(message.mmsAttachmentType))
-                .replaceAll("%mmsFilename%",
-                        Matcher.quoteReplacement(message.getMmsFilename()));
+                .replace("%messageType%", message.messageType)
+                .replace("%fromName%", message.senderName)
+                .replace("%from%", message.senderPhoneNumber)
+                .replace("%sentStamp%", String.valueOf(message.timestamp))
+                .replace("%receivedStamp%", String.valueOf(System.currentTimeMillis()))
+                .replace("%sim%", message.simSlotName)
+                .replace("%text%", StringEscapeUtils.escapeJson(message.messageContent))
+                .replace("%mmsSubject%", StringEscapeUtils.escapeJson(message.mmsSubject))
+                .replace("%mmsAttachmentB64%", message.mmsAttachmentB64)
+                .replace("%mmsAttachmentType%", message.mmsAttachmentType)
+                .replace("%mmsFilename%", message.getMmsFilename())
+                .replace("%timestamp%", String.valueOf(System.currentTimeMillis()));
     }
 
     public String prepareMessage(WebhookMessage message) {
@@ -325,6 +335,14 @@ public class ForwardingConfig {
 
     public String prepareHeaders(WebhookMessage message) {
         return applyPlaceholders(this.getHeaders(), message);
+    }
+
+    public String prepareUrl(WebhookMessage message) {
+        return applyPlaceholders(this.getUrl(), message);
+    }
+
+    public String prepareAttachmentUrl(WebhookMessage message) {
+        return applyPlaceholders(this.getAttachmentUrl(), message);
     }
 
     public String prepareAttachmentHeaders(WebhookMessage message) {

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/ForwardingConfigDialog.java
@@ -65,6 +65,7 @@ public class ForwardingConfigDialog {
         final CheckBox chunkedModeCheckbox = view.findViewById(R.id.input_chunked_mode);
         chunkedModeCheckbox.setChecked(true);
 
+        prepareRequestMethodSpinner(view, "POST");
         prepareSimSelector(context, view, 0);
         prepareAttachmentFields(view, false, "", "PUT",
                 ForwardingConfig.getDefaultAttachmentHeaders());
@@ -124,6 +125,8 @@ public class ForwardingConfigDialog {
         final CheckBox chunkedModeCheckbox = view.findViewById(R.id.input_chunked_mode);
         chunkedModeCheckbox.setChecked(config.getChunkedMode());
 
+        prepareRequestMethodSpinner(view, config.getRequestMethod());
+
         prepareAttachmentFields(view, config.getAttachmentUploadEnabled(),
                 config.getAttachmentUrl(), config.getAttachmentMethod(),
                 config.getAttachmentHeaders());
@@ -170,7 +173,7 @@ public class ForwardingConfigDialog {
             return null;
         }
         try {
-            new URL(url);
+            new URL(stripPlaceholders(url));
         } catch (MalformedURLException e) {
             urlInput.setError(context.getString(R.string.error_wrong_url));
             return null;
@@ -211,6 +214,9 @@ public class ForwardingConfigDialog {
         final CheckBox chunkedModeCheckbox = view.findViewById(R.id.input_chunked_mode);
         boolean chunkedMode = chunkedModeCheckbox.isChecked();
 
+        Spinner requestMethodSpinner = view.findViewById(R.id.input_request_method);
+        String requestMethod = (String) requestMethodSpinner.getSelectedItem();
+
         config.setSender(sender);
         config.setUrl(url);
         config.setTemplate(template);
@@ -218,6 +224,7 @@ public class ForwardingConfigDialog {
         config.setRetriesNumber(retriesNum);
         config.setIgnoreSsl(ignoreSsl);
         config.setChunkedMode(chunkedMode);
+        config.setRequestMethod(requestMethod);
 
         // Attachment upload fields
         final CheckBox attachmentCheckbox = view.findViewById(R.id.input_attachment_upload_enabled);
@@ -232,7 +239,7 @@ public class ForwardingConfigDialog {
                 return null;
             }
             try {
-                new URL(attachmentUrl);
+                new URL(stripPlaceholders(attachmentUrl));
             } catch (MalformedURLException e) {
                 attachmentUrlInput.setError(context.getString(R.string.error_wrong_attachment_url));
                 return null;
@@ -254,6 +261,16 @@ public class ForwardingConfigDialog {
         }
 
         return config;
+    }
+
+    private void prepareRequestMethodSpinner(View view, String selected) {
+        Spinner methodSpinner = view.findViewById(R.id.input_request_method);
+        String[] methods = {"POST", "PUT"};
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(context,
+                android.R.layout.simple_spinner_item, methods);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        methodSpinner.setAdapter(adapter);
+        methodSpinner.setSelection("PUT".equals(selected) ? 1 : 0);
     }
 
     private void prepareAttachmentFields(View view, boolean enabled, String url,
@@ -328,6 +345,10 @@ public class ForwardingConfigDialog {
             (byte) 0xae, 0x42, 0x60, (byte) 0x82
     };
 
+    private static String stripPlaceholders(String input) {
+        return input.replaceAll("%[a-zA-Z]+%", "placeholder");
+    }
+
     private void testConfig(ForwardingConfig config) {
         if (config == null) {
             return;
@@ -341,10 +362,11 @@ public class ForwardingConfigDialog {
 
             // send the normal templated text webhook
             String payload = config.prepareMessage(testMessage);
-            Request request = new Request(config.getUrl(), payload);
+            Request request = new Request(config.prepareUrl(testMessage), payload);
             request.setJsonHeaders(config.prepareHeaders(testMessage));
             request.setIgnoreSsl(config.getIgnoreSsl());
             request.setUseChunkedMode(config.getChunkedMode());
+            request.setRequestMethod(config.getRequestMethod());
 
             String result = request.execute();
             if (!Objects.equals(result, Request.RESULT_SUCCESS)) {
@@ -358,7 +380,7 @@ public class ForwardingConfigDialog {
             if (config.getAttachmentUploadEnabled()) {
                 String headers = config.prepareAttachmentHeaders(testMessage);
                 BinaryRequest binReq = new BinaryRequest(
-                        config.getAttachmentUrl(),
+                        config.prepareAttachmentUrl(testMessage),
                         config.getAttachmentMethod(),
                         TEST_PNG,
                         "image/png");

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/MmsBroadcastReceiver.java
@@ -341,7 +341,7 @@ public class MmsBroadcastReceiver extends ContentObserver {
 
         new Thread(() -> {
             for (int attempt = 0; attempt <= maxRetries; attempt++) {
-                Request request = new Request(config.getUrl(), strMessage);
+                Request request = new Request(config.prepareUrl(message), strMessage);
                 request.setJsonHeaders(config.prepareHeaders(message));
                 request.setIgnoreSsl(config.getIgnoreSsl());
                 request.setUseChunkedMode(config.getChunkedMode());
@@ -371,7 +371,7 @@ public class MmsBroadcastReceiver extends ContentObserver {
         new Thread(() -> {
             for (int attempt = 0; attempt <= maxRetries; attempt++) {
                 BinaryRequest request = new BinaryRequest(
-                        config.getAttachmentUrl(),
+                        config.prepareAttachmentUrl(message),
                         config.getAttachmentMethod(),
                         message.mmsAttachmentData,
                         message.mmsAttachmentType);

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/Request.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/Request.java
@@ -30,6 +30,7 @@ public class Request {
     private final String payload;
     private boolean ignoreSsl = false;
     private boolean useChunkedMode = true;
+    private String requestMethod = "POST";
     private String error = null;
 
     private HttpURLConnection connection;
@@ -96,6 +97,10 @@ public class Request {
         this.useChunkedMode = useChunkedMode;
     }
 
+    public void setRequestMethod(String method) {
+        this.requestMethod = method;
+    }
+
     @SuppressLint({"AllowAllHostnameVerifier"})
     public String execute() {
         if (this.error != null) {
@@ -115,6 +120,7 @@ public class Request {
                 }
             }
 
+            this.connection.setRequestMethod(this.requestMethod);
             this.connection.setDoOutput(true);
             if (this.useChunkedMode) {
                 this.connection.setChunkedStreamingMode(0);

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/RequestWorker.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/RequestWorker.java
@@ -14,6 +14,7 @@ public class RequestWorker extends Worker {
     public final static String DATA_IGNORE_SSL = "IGNORE_SSL";
     public final static String DATA_MAX_RETRIES = "MAX_RETRIES";
     public final static String DATA_CHUNKED_MODE = "CHUNKED_MODE";
+    public final static String DATA_REQUEST_METHOD = "REQUEST_METHOD";
 
     public RequestWorker(
             @NonNull Context context,
@@ -35,11 +36,14 @@ public class RequestWorker extends Worker {
         String headers = getInputData().getString(DATA_HEADERS);
         boolean ignoreSsl = getInputData().getBoolean(DATA_IGNORE_SSL, false);
         boolean useChunkedMode = getInputData().getBoolean(DATA_CHUNKED_MODE, true);
+        String requestMethod = getInputData().getString(DATA_REQUEST_METHOD);
+        if (requestMethod == null) requestMethod = "POST";
 
         Request request = new Request(url, text);
         request.setJsonHeaders(headers);
         request.setIgnoreSsl(ignoreSsl);
         request.setUseChunkedMode(useChunkedMode);
+        request.setRequestMethod(requestMethod);
 
         String result = request.execute();
 

--- a/app/src/main/java/org/scottmconway/incomingsmsgateway/SmsBroadcastReceiver.java
+++ b/app/src/main/java/org/scottmconway/incomingsmsgateway/SmsBroadcastReceiver.java
@@ -174,12 +174,13 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
                 .build();
 
         Data data = new Data.Builder()
-                .putString(RequestWorker.DATA_URL, config.getUrl())
+                .putString(RequestWorker.DATA_URL, config.prepareUrl(message))
                 .putString(RequestWorker.DATA_TEXT, strMessage)
                 .putString(RequestWorker.DATA_HEADERS, config.prepareHeaders(message))
                 .putBoolean(RequestWorker.DATA_IGNORE_SSL, config.getIgnoreSsl())
                 .putBoolean(RequestWorker.DATA_CHUNKED_MODE, config.getChunkedMode())
                 .putInt(RequestWorker.DATA_MAX_RETRIES, config.getRetriesNumber())
+                .putString(RequestWorker.DATA_REQUEST_METHOD, config.getRequestMethod())
                 .build();
 
         WorkRequest workRequest =

--- a/app/src/main/res/layout/dialog_config_edit_form.xml
+++ b/app/src/main/res/layout/dialog_config_edit_form.xml
@@ -77,6 +77,23 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:layout_marginLeft="12dp"
+            android:layout_marginTop="16dp"
+            android:labelFor="@+id/input_request_method"
+            android:text="@string/label_request_method" />
+
+        <Spinner
+            android:id="@+id/input_request_method"
+            android:layout_width="fill_parent"
+            android:layout_marginStart="5dp"
+            android:layout_marginLeft="5dp"
+            android:popupTheme="@style/AppTheme.Spinner"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginLeft="12dp"
             android:layout_marginTop="18dp"
             android:textColor="@color/colorBlack"
             android:textSize="16sp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="label_number_retries">Number of retries</string>
     <string name="label_sender">Sender</string>
     <string name="label_url">Webhook URL</string>
+    <string name="label_request_method">HTTP Method</string>
     <string name="label_json_template">Json Payload Template</string>
     <string name="label_json_headers">Headers</string>
     <string name="label_sim_slot">Sim Slot</string>


### PR DESCRIPTION
This PR adds possibility to select request method and allows user to use placeholders right in url

- request method: POST or PUT
- placeholders support in url
- new placeholder %timestamp% adds system time with millis to prevent server cache issues
- replaceAll() change to replace() to avoid regexp issues